### PR TITLE
Fix build on MacOS X

### DIFF
--- a/README.Linux.md
+++ b/README.Linux.md
@@ -1,0 +1,63 @@
+V8Js on GNU/Linux
+=================
+
+Installation of V8Js on GNU/Linux is pretty much straight forward.
+
+The biggest hurdle actually is that you need a rather new v8 library.
+However most distributions still ship the rusty version 3.14, publish
+years ago, since Node.js requires such an old version.
+
+This means that you usually need to compile v8 on your own before
+you can start to compile & install v8js itself.
+
+Compile latest v8
+-----------------
+
+```
+cd /tmp
+
+# Install depot_tools first (needed for source checkout)
+git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
+export PATH=`pwd`/depot_tools:"$PATH"
+
+# Download v8
+fetch v8
+cd v8
+
+# (optional) If you'd like to build a certain version:
+git checkout 3.32.6
+gclient sync
+
+# Build
+make native library=shared -j8
+
+# Install to /usr
+sudo mkdir -p /usr/lib /usr/include
+sudo cp out/native/lib.target/lib*.so /usr/lib/
+sudo cp -R include/* /usr/include
+echo -e "create /usr/lib/libv8_libplatform.a\naddlib out/native/obj.target/tools/gyp/libv8_libplatform.a\nsave\nend" | sudo ar -M
+```
+
+If you don't want to overwrite the system copy of v8, replace `/usr` in
+the above commands with `/tmp/v8-install` and then add
+`--with-v8js=/tmp/v8-install` to the php-v8js `./configure` command below.
+
+`libv8_libplatform.a` should not be copied directly since it's a thin
+archive, i.e. it contains only pointers to the build objects, which
+otherwise must not be deleted.  The simple mri-script converts the
+thin archive to a normal archive.
+
+
+Compile php-v8js itself
+-----------------------
+
+```
+cd /tmp
+git clone https://github.com/preillyme/v8js.git
+cd v8js
+phpize
+./configure
+make
+make test
+sudo make install
+```

--- a/README.MacOS.md
+++ b/README.MacOS.md
@@ -1,0 +1,79 @@
+V8Js on MacOS
+=============
+
+Installation of V8Js on MacOS is pretty much straight forward.
+
+First of all you need a pretty fresh installation of v8 library.
+If you have brew around, just `brew install v8` and you should be done.
+Otherwise you need to compile latest v8 manually.
+
+Compile latest v8
+-----------------
+
+```
+cd /tmp
+
+# Install depot_tools first (needed for source checkout)
+git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
+export PATH=`pwd`/depot_tools:"$PATH"
+
+# Download v8
+fetch v8
+cd v8
+
+# (optional) If you'd like to build a certain version:
+git checkout 3.32.6
+gclient sync
+
+# Build
+make native library=shared -j8
+
+# Install to /usr
+mkdir -p /usr/local/lib /usr/local/include
+cp out/native/lib*.dylib /usr/local/lib/
+cp out/native/libv8_*.a  /usr/local/lib/
+cp -R include/* /usr/local/include
+```
+
+You cannot install the libraries to any location you want since they
+have a install name that is baked into the library.  You can check
+the install name with `otool -D out/native/libv8.dylib`.
+
+During the build snapshot generation may fail like so:
+
+```
+ACTION tools_gyp_v8_gyp_v8_snapshot_target_run_mksnapshot /Users/vagrant/v8/out/native/obj.target/v8_snapshot/geni/snapshot.cc
+dyld: Library not loaded: /usr/local/lib/libicui18n.dylib
+  Referenced from: /Users/vagrant/v8/out/native/mksnapshot
+  Reason: image not found
+/bin/sh: line 1: 18964 Trace/BPT trap: 5       "/Users/vagrant/v8/out/native/mksnapshot" --log-snapshot-positions --logfile "/Users/vagrant/v8/out/native/obj.target/v8_snapshot/geni/snapshot.log" --random-seed 314159265 "/Users/vagrant/v8/out/native/obj.target/v8_snapshot/geni/snapshot.cc"
+make[1]: *** [/Users/vagrant/v8/out/native/obj.target/v8_snapshot/geni/snapshot.cc] Error 133
+make: *** [native] Error 2
+```
+
+... if that happens, just copy libicu*.dylib to /usr/local/lib already
+and start make again (then simply continue with installation):
+
+```
+cp out/native/libicu*.dylib /usr/local/lib/
+make native library=shared -j8
+```
+
+
+Compile php-v8js itself
+-----------------------
+
+If you're using Apple LLVM compiler (instead of gcc) you need to pass the `-Wno-c++11-narrowing`
+flag.  Otherwise compilation fails due to narrowing errors in PHP itself, which LLVM is much pickier
+with (compared to gcc).
+
+```
+cd /tmp
+git clone https://github.com/preillyme/v8js.git
+cd v8js
+phpize
+./configure CXXFLAGS="-Wno-c++11-narrowing"
+make
+make test
+make install
+```

--- a/README.md
+++ b/README.md
@@ -23,58 +23,22 @@ Minimum requirements
 
   This embedded implementation of the V8 engine uses thread locking so it should work with ZTS enabled.
   However, this has not been tested yet.
-  
-COMPILING LATEST VERSION
-========================
 
-Instead of compiling manually you might want to pull from the [V8Js docker
-repository](https://registry.hub.docker.com/u/stesie/v8js/).
+
+Compiling latest version
+------------------------
+
+For some very first steps, instead of compiling manually you might want to try out the [V8Js docker
+image](https://registry.hub.docker.com/u/stesie/v8js/).  It has v8, v8js and php-cli pre-installed
+so you can give it a try with PHP in "interactive mode".  There is no Apache, etc. running however.
 
 You also might want to try the Debian & Ubuntu packages available from
 the Jenkins site at https://jenkins.brokenpipe.de/
 
-Building on Microsoft Windows is more complicated, see README.Win32.md file
-for a quick run through.
-
-Compile latest v8
------------------
-
-```
-cd /tmp
-git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
-export PATH=`pwd`/depot_tools:"$PATH"
-git clone https://github.com/v8/v8.git
-cd v8
-make dependencies
-make native library=shared -j8
-sudo mkdir -p /usr/lib /usr/include
-sudo cp out/native/lib.target/lib*.so /usr/lib/
-echo -e "create /usr/lib/libv8_libplatform.a\naddlib out/native/obj.target/tools/gyp/libv8_libplatform.a\nsave\nend" | sudo ar -M
-sudo cp -R include/* /usr/include
-
-```
-
-If you don't want to overwrite the system copy of v8, replace `/usr` in
-the above commands with `/tmp/v8-install` and then add
-`--with-v8js=/tmp/v8-install` to the php-v8js `./configure` command below.
-
-`libv8_libplatform.a` should not be copied directly since it's a thin
-archive, i.e. it contains only pointers to  the build objects, which
-otherwise must not be deleted.  The simple mri-script converts the
-thin archive to a normal archive.
-
-Compile php-v8js itself
------------------------
-
-```
-cd /tmp
-git clone https://github.com/preillyme/v8js.git
-cd v8js
-phpize
-./configure
-make
-sudo make install
-```
+Building on Microsoft Windows is a bit more involved, see README.Win32.md file
+for a quick run through.  Building on GNU/Linux and MacOS X is straight forward,
+see README.Linux.md and README.MacOS.md files for a walk through with platform
+specific notes.
 
 
 PHP API

--- a/config.m4
+++ b/config.m4
@@ -110,22 +110,32 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <v8-debug.h>]],
     dnl link in libplatform to make our life easier.
     PHP_ADD_INCLUDE($V8_DIR)
 
-    SEARCH_FOR="lib/libv8_libplatform.a"
-    AC_MSG_CHECKING([for libv8_libplatform.a])
+    case $host_os in
+      darwin* )
+        static_link_extra="libv8_libplatform.a libv8_libbase.a"
+        ;;
+      * )
+        static_link_extra="libv8_libplatform.a"
+        ;;
+    esac
 
-    for i in $PHP_V8JS $SEARCH_PATH ; do
-      if test -r $i/$SEARCH_FOR; then
-        LIBPLATFORM_DIR=$i
-        AC_MSG_RESULT(found in $i)
+    for static_link_extra_file in $static_link_extra; do
+      AC_MSG_CHECKING([for $static_link_extra_file])
+
+      for i in $PHP_V8JS $SEARCH_PATH ; do
+        if test -r $i/lib/$static_link_extra_file; then
+          static_link_dir=$i
+          AC_MSG_RESULT(found in $i)
+        fi
+      done
+
+      if test -z "$static_link_dir"; then
+        AC_MSG_RESULT([not found])
+        AC_MSG_ERROR([Please provide $static_link_extra_file next to the libv8.so, see README.md for details])
       fi
+
+      LDFLAGS="$LDFLAGS $static_link_dir/lib/$static_link_extra_file"
     done
-
-    if test -z "$LIBPLATFORM_DIR"; then
-      AC_MSG_RESULT([not found])
-      AC_MSG_ERROR([Please provide libv8_libplatform.a next to the libv8.so, see README.md for details])
-    fi
-
-    LDFLAGS="$LDFLAGS $LIBPLATFORM_DIR/$SEARCH_FOR"
   fi
 
   AC_CACHE_CHECK(for C standard version, ac_cv_v8_cstd, [

--- a/config.m4
+++ b/config.m4
@@ -6,7 +6,14 @@ if test "$PHP_V8JS" != "no"; then
   SEARCH_FOR="include/v8.h"
   
   if test -r $PHP_V8JS/$SEARCH_FOR; then
-    LDFLAGS="$LDFLAGS -Wl,--rpath=$PHP_V8JS/$PHP_LIBDIR"
+    case $host_os in
+      darwin* )
+        # MacOS does not support --rpath
+        ;;
+      * )
+        LDFLAGS="$LDFLAGS -Wl,--rpath=$PHP_V8JS/$PHP_LIBDIR"
+        ;;
+    esac
     V8_DIR=$PHP_V8JS
   else
     AC_MSG_CHECKING([for V8 files in default path])
@@ -31,7 +38,17 @@ if test "$PHP_V8JS" != "no"; then
   old_LIBS=$LIBS
   old_LDFLAGS=$LDFLAGS
   old_CPPFLAGS=$CPPFLAGS
-  LDFLAGS="-Wl,--rpath=$V8_DIR/$PHP_LIBDIR -L$V8_DIR/$PHP_LIBDIR"
+
+  case $host_os in
+    darwin* )
+      # MacOS does not support --rpath
+      LDFLAGS="-L$V8_DIR/$PHP_LIBDIR"
+      ;;
+    * )
+      LDFLAGS="-Wl,--rpath=$V8_DIR/$PHP_LIBDIR -L$V8_DIR/$PHP_LIBDIR"
+      ;;
+  esac
+
   LIBS=-lv8
   CPPFLAGS=-I$V8_DIR/include
   AC_LANG_SAVE


### PR DESCRIPTION
This fixes config.m4 to use -rpath linking on GNU/Linux only and link against libv8_libbase.a along with libv8_libplatform.a
Besides added build instructions in README.MacOS.md file

This fixes #97