### PR TITLE
Provide v8::ArrayBufferAllocator as needed

### DIFF
--- a/v8js_class.cc
+++ b/v8js_class.cc
@@ -65,6 +65,17 @@ struct v8js_jsext {
 };
 /* }}} */
 
+#if PHP_V8_API_VERSION >= 4004044
+class ArrayBufferAllocator : public v8::ArrayBuffer::Allocator {
+public:
+	virtual void* Allocate(size_t length) {
+		void* data = AllocateUninitialized(length);
+		return data == NULL ? data : memset(data, 0, length);
+	}
+	virtual void* AllocateUninitialized(size_t length) { return malloc(length); }
+	virtual void Free(void* data, size_t) { free(data); }
+};
+#endif
 
 static void v8js_free_storage(void *object TSRMLS_DC) /* {{{ */
 {
@@ -303,7 +314,16 @@ static PHP_METHOD(V8Js, __construct)
 	c->report_uncaught = report_uncaught;
 	c->pending_exception = NULL;
 	c->in_execution = 0;
+
+#if PHP_V8_API_VERSION >= 4004044
+	static ArrayBufferAllocator array_buffer_allocator;
+	static v8::Isolate::CreateParams create_params;
+	create_params.array_buffer_allocator = &array_buffer_allocator;
+	c->isolate = v8::Isolate::New(create_params);
+#else
 	c->isolate = v8::Isolate::New();
+#endif
+
 	c->isolate->SetData(0, c);
 
 	c->time_limit = 0;

--- a/v8js_class.cc
+++ b/v8js_class.cc
@@ -65,7 +65,7 @@ struct v8js_jsext {
 };
 /* }}} */
 
-#if PHP_V8_API_VERSION >= 4004044
+#if PHP_V8_API_VERSION >= 4004010
 class ArrayBufferAllocator : public v8::ArrayBuffer::Allocator {
 public:
 	virtual void* Allocate(size_t length) {
@@ -1070,6 +1070,11 @@ PHP_MINIT_FUNCTION(v8js_class) /* {{{ */
 #endif
 
 	le_v8js_script = zend_register_list_destructors_ex(v8js_script_dtor, NULL, PHP_V8JS_SCRIPT_RES_NAME, module_number);
+
+#if PHP_V8_API_VERSION >= 4004010 && PHP_V8_API_VERSION < 4004044
+	static ArrayBufferAllocator array_buffer_allocator;
+	v8::V8::SetArrayBufferAllocator(&array_buffer_allocator);
+#endif
 
 	return SUCCESS;
 } /* }}} */


### PR DESCRIPTION
v8 allows to provide custom `ArrayBufferAllocator` instances to it for quite some time now (it was even possible to do so with the major version 3 line)

At some point in the 4.4 minor version line it now became necessary to provide one, otherwise leading to crashes. I've tried and version 4.4.43 definitely doesn't work if `v8::V8::SetArrayBufferAllocator` is not called before creating a first `v8::Isolate`. Contrary 4.4.10 definitely works without.

Also with version 4.4.44 there now is a `v8::Isolate::New` static function that allows passing a `v8::Isolate::CreateParams` instance that links the `ArrayBufferAllocator`; ... and now the parameter-less version of `v8::Isolate::New` was removed in the 4.6 line (so v8js cannot be compiled even more)

This patch changes v8js behaviour, so
* that it uses the SetArrayBufferAllocator API for versions 4.4.10 to 4.4.43
* and the new v8::Isolate::CreateParams API from 4.4.44 on
