### PR TITLE
skip extensions_error test for v8 version < 3.30

### DIFF
--- a/tests/extensions_error.phpt
+++ b/tests/extensions_error.phpt
@@ -1,7 +1,24 @@
 --TEST--
 Test V8::registerExtension() : Register extension with errors
 --SKIPIF--
-<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+<?php
+require_once(dirname(__FILE__) . '/skipif.inc');
+
+ob_start(NULL, 0, PHP_OUTPUT_HANDLER_CLEANABLE | PHP_OUTPUT_HANDLER_REMOVABLE);
+phpinfo(INFO_MODULES);
+$minfo = ob_get_contents();
+ob_end_clean();
+
+if(preg_match("/V8 Engine Linked Version => (.*)/", $minfo, $matches)) {
+    $version = explode('.', $matches[1]);
+    if($version[0] < 3 || ($version[0] == 3 && $version[1] < 30)) {
+	// old v8 version, has shorter error message and hence doesn't
+	// fit our EXCEPTF below
+	echo "skip";
+    }
+}
+
+?>
 --FILE--
 <?php
 


### PR DESCRIPTION
The raised error messages during extension bootstrap phase have changed, hence the tests I've added recently, fail with older v8 versions.

This patch simply skips the test in question for v8 versions for 3.29 line and below