### PR TITLE
Memory Leak Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ v8js.la
 /tests/*.out
 /tests/*.php
 /tests/*.sh
+/tests/*.mem

--- a/php_v8js_macros.h
+++ b/php_v8js_macros.h
@@ -115,6 +115,9 @@ void v8js_register_accessors(std::vector<v8js_accessor_ctx*> *accessor_list, v8:
 /* Module globals */
 ZEND_BEGIN_MODULE_GLOBALS(v8js)
   int v8_initialized;
+#if !defined(_WIN32) && PHP_V8_API_VERSION >= 3029036
+  v8::Platform *v8_platform;
+#endif
   HashTable *extensions;
 
   /* Ini globals */

--- a/v8js.cc
+++ b/v8js.cc
@@ -200,6 +200,14 @@ static PHP_GSHUTDOWN_FUNCTION(v8js)
 	v8js_globals->timer_stack.~deque();
 	v8js_globals->timer_mutex.~mutex();
 #endif
+
+	if (v8js_globals->v8_initialized) {
+		v8::V8::Dispose();
+		v8::V8::ShutdownPlatform();
+#if !defined(_WIN32) && PHP_V8_API_VERSION >= 3029036
+		delete v8js_globals->v8_platform;
+#endif
+	}
 }
 /* }}} */
 

--- a/v8js_class.cc
+++ b/v8js_class.cc
@@ -50,7 +50,7 @@ typedef struct _v8js_script {
 	v8::Persistent<v8::Script, v8::CopyablePersistentTraits<v8::Script>> *script;
 } v8js_script;
 
-static void v8js_script_free(v8js_script *res, bool dispose_persistent);
+static void v8js_script_free(v8js_script *res);
 
 int le_v8js_script;
 
@@ -545,7 +545,7 @@ static PHP_METHOD(V8Js, executeString)
 		RETURN_FALSE;
 	}
 	v8js_execute_script(getThis(), res, flags, time_limit, memory_limit, &return_value TSRMLS_CC);
-	v8js_script_free(res, true);
+	v8js_script_free(res);
 	efree(res);
 }
 /* }}} */
@@ -611,7 +611,7 @@ static PHP_METHOD(V8Js, checkString)
 		RETURN_FALSE;
 	}
 
-	v8js_script_free(res, true);
+	v8js_script_free(res);
 	efree(res);
 	RETURN_TRUE;
 }
@@ -768,23 +768,17 @@ static void v8js_persistent_zval_dtor(zval **p) /* {{{ */
 }
 /* }}} */
 
-static void v8js_script_free(v8js_script *res, bool dispose_persistent)
+static void v8js_script_free(v8js_script *res)
 {
-	if (res->name) {
-		efree(res->name);
-		res->name = NULL;
-	}
-	if (dispose_persistent) {
-		delete res->script; // does Reset()
-		res->script = NULL;
-	}
+	efree(res->name);
+	delete res->script; // does Reset()
 }
 
 static void v8js_script_dtor(zend_rsrc_list_entry *rsrc TSRMLS_DC) /* {{{ */
 {
 	v8js_script *res = (v8js_script *)rsrc->ptr;
 	if (res) {
-		v8js_script_free(res, false);
+		v8js_script_free(res);
 		efree(res);
 	}
 }

--- a/v8js_class.cc
+++ b/v8js_class.cc
@@ -775,7 +775,7 @@ static void v8js_script_free(v8js_script *res, bool dispose_persistent)
 		res->name = NULL;
 	}
 	if (dispose_persistent) {
-		res->script->~Persistent(); // does Reset()
+		delete res->script; // does Reset()
 		res->script = NULL;
 	}
 }

--- a/v8js_class.h
+++ b/v8js_class.h
@@ -22,6 +22,7 @@ typedef v8::Persistent<v8::Object, v8::CopyablePersistentTraits<v8::Object> > v8
 /* Forward declarations */
 struct v8js_v8object;
 struct v8js_accessor_ctx;
+struct _v8js_script;
 
 /* {{{ Context container */
 struct v8js_ctx {
@@ -52,6 +53,7 @@ struct v8js_ctx {
   std::list<v8js_v8object *> v8js_v8objects;
 
   std::vector<v8js_accessor_ctx *> accessor_list;
+  std::vector<struct _v8js_script *> script_objects;
   char *tz;
 #ifdef ZTS
   void ***zts_ctx;

--- a/v8js_v8.cc
+++ b/v8js_v8.cc
@@ -42,8 +42,8 @@ void v8js_v8_init(TSRMLS_D) /* {{{ */
 	}
 
 #if !defined(_WIN32) && PHP_V8_API_VERSION >= 3029036
-	v8::Platform* platform = v8::platform::CreateDefaultPlatform();
-	v8::V8::InitializePlatform(platform);
+	V8JSG(v8_platform) = v8::platform::CreateDefaultPlatform();
+	v8::V8::InitializePlatform(V8JSG(v8_platform));
 #endif
 
 	/* Set V8 command line flags (must be done before V8::Initialize()!) */


### PR DESCRIPTION
* correctly shutdown V8 library & platform on PHP shutdown
* track v8::Extension objects and release them on shutdown
* always release v8::Script instances
* track persisted v8::Script instances (resources) and reset them on V8Js object disposal