### PR TITLE
PHP->JS exception propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ class V8Js
 
     const FLAG_NONE = 1;
     const FLAG_FORCE_ARRAY = 2;
+    const FLAG_PROPAGATE_PHP_EXCEPTIONS = 4;
 
     const DEBUG_AUTO_BREAK_NEVER = 1;
     const DEBUG_AUTO_BREAK_ONCE = 2;
@@ -297,3 +298,21 @@ PHP Objects implementing ArrayAccess, Countable
 The above rule that PHP objects are generally converted to JavaScript objects also applies to PHP objects of `ArrayObject` type or other classes, that implement both the `ArrayAccess` and the `Countable` interface -- even so they behave like PHP arrays.
 
 This behaviour can be changed by enabling the php.ini flag `v8js.use_array_access`.  If set, objects of PHP classes that implement the aforementioned interfaces are converted to JavaScript Array-like objects.  This is by-index access of this object results in immediate calls to the `offsetGet` or `offsetSet` PHP methods (effectively this is live-binding of JavaScript against the PHP object).  Such an Array-esque object also supports calling every attached public method of the PHP object + methods of JavaScript's native Array.prototype methods (as long as they are not overloaded by PHP methods).
+
+Exceptions
+----------
+
+If the JavaScript code throws (without catching), causes errors or doesn't
+compile, `V8JsScriptException` exceptions are thrown unless the `V8Js` object
+is constructed with `report_uncaught_exceptions` set `FALSE`.
+
+PHP exceptions that occur due to calls from JavaScript code by default are
+*not* re-thrown into JavaScript context but cause the JavaScript execution to
+be stopped immediately.
+
+This behaviour can be changed by setting the `FLAG_PROPAGATE_PHP_EXCEPTIONS`
+flag.  If it is set, PHP exception (objects) are converted to JavaScript
+objects obeying the above rules and re-thrown in JavaScript context.  If they
+are not caught by JavaScript code the execution stops and a
+`V8JsScriptException` is thrown, which has the original PHP exception accessible
+via `getPrevious` method.

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ The above rule that PHP objects are generally converted to JavaScript objects al
 This behaviour can be changed by enabling the php.ini flag `v8js.use_array_access`.  If set, objects of PHP classes that implement the aforementioned interfaces are converted to JavaScript Array-like objects.  This is by-index access of this object results in immediate calls to the `offsetGet` or `offsetSet` PHP methods (effectively this is live-binding of JavaScript against the PHP object).  Such an Array-esque object also supports calling every attached public method of the PHP object + methods of JavaScript's native Array.prototype methods (as long as they are not overloaded by PHP methods).
 
 Exceptions
-----------
+==========
 
 If the JavaScript code throws (without catching), causes errors or doesn't
 compile, `V8JsScriptException` exceptions are thrown unless the `V8Js` object
@@ -308,7 +308,7 @@ is constructed with `report_uncaught_exceptions` set `FALSE`.
 
 PHP exceptions that occur due to calls from JavaScript code by default are
 *not* re-thrown into JavaScript context but cause the JavaScript execution to
-be stopped immediately.
+be stopped immediately and then are reported at the location calling the JS code.
 
 This behaviour can be changed by setting the `FLAG_PROPAGATE_PHP_EXCEPTIONS`
 flag.  If it is set, PHP exception (objects) are converted to JavaScript
@@ -316,3 +316,10 @@ objects obeying the above rules and re-thrown in JavaScript context.  If they
 are not caught by JavaScript code the execution stops and a
 `V8JsScriptException` is thrown, which has the original PHP exception accessible
 via `getPrevious` method.
+
+V8Js versions 0.2.4 and before did not stop JS code execution on PHP exceptions,
+but silently ignored them (even so succeeding PHP calls from within the same piece
+of JS code were not executed by the PHP engine).  This behaviour is considered as
+a bug and hence was fixed with 0.2.5 release.  Nevertheless there is a 
+compatibility php.ini switch (`v8js.compat_php_exceptions`) which turns previous
+behaviour back on.

--- a/php_v8js_macros.h
+++ b/php_v8js_macros.h
@@ -83,6 +83,7 @@ extern "C" {
 /* Options */
 #define V8JS_FLAG_NONE			(1<<0)
 #define V8JS_FLAG_FORCE_ARRAY	(1<<1)
+#define V8JS_FLAG_PROPAGATE_PHP_EXCEPTIONS	(1<<2)
 
 #define V8JS_DEBUG_AUTO_BREAK_NEVER		0
 #define V8JS_DEBUG_AUTO_BREAK_ONCE		1

--- a/php_v8js_macros.h
+++ b/php_v8js_macros.h
@@ -121,6 +121,7 @@ ZEND_BEGIN_MODULE_GLOBALS(v8js)
   char *v8_flags; /* V8 command line flags */
   bool use_date; /* Generate JS Date objects instead of PHP DateTime */
   bool use_array_access; /* Convert ArrayAccess, Countable objects to array-like objects */
+  bool compat_php_exceptions; /* Don't stop JS execution on PHP exception */
 
   // Timer thread globals
   std::deque<v8js_timer_ctx *> timer_stack;

--- a/php_v8js_macros.h
+++ b/php_v8js_macros.h
@@ -80,10 +80,6 @@ extern "C" {
 # define V8JS_CONST (char *)
 #endif
 
-/* Global flags */
-#define V8JS_GLOBAL_SET_FLAGS(isolate,flags)	V8JS_GLOBAL(isolate)->SetHiddenValue(V8JS_SYM("__php_flags__"), V8JS_INT(flags))
-#define V8JS_GLOBAL_GET_FLAGS(isolate)			V8JS_GLOBAL(isolate)->GetHiddenValue(V8JS_SYM("__php_flags__"))->IntegerValue();
-
 /* Options */
 #define V8JS_FLAG_NONE			(1<<0)
 #define V8JS_FLAG_FORCE_ARRAY	(1<<1)

--- a/tests/exception_propagation_2.phpt
+++ b/tests/exception_propagation_2.phpt
@@ -1,6 +1,7 @@
 --TEST--
 Test V8::executeString() : Exception propagation test 2
 --SKIPIF--
+SKIP needs discussion, see issue #144
 <?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
 --FILE--
 <?php

--- a/tests/issue_156_001.phpt
+++ b/tests/issue_156_001.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Test V8::executeString() : Backwards compatibility for issue #156
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+--INI--
+v8js.compat_php_exceptions = 1
+--FILE--
+<?php
+
+$v8 = new V8Js();
+
+$v8->throwPHPException = function () {
+    echo "throwing PHP exception now ...\n";
+    throw new \Exception('foo');
+};
+
+$JS = <<< EOT
+PHP.throwPHPException();
+print("... old behaviour was to not stop JS execution on PHP exceptions\\n");
+EOT;
+
+try {
+    $v8->executeString($JS, 'issue_156_001.js');
+} catch(Exception $e) {
+    var_dump($e->getMessage());
+}
+?>
+===EOF===
+--EXPECT--
+throwing PHP exception now ...
+... old behaviour was to not stop JS execution on PHP exceptions
+string(3) "foo"
+===EOF===

--- a/tests/php_exceptions_001.phpt
+++ b/tests/php_exceptions_001.phpt
@@ -1,0 +1,50 @@
+--TEST--
+Test V8::executeString() : PHP Exception handling (repeated)
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+--FILE--
+<?php
+
+class Foo {
+    function throwException() {
+	throw new \Exception("Test-Exception");
+    }
+}
+
+$v8 = new V8Js();
+$v8->foo = new \Foo();
+
+$JS = <<< EOT
+try {
+    PHP.foo.throwException();
+    // the exception should abort further execution,
+    // hence the print must not pop up
+    print("after throwException\\n");
+} catch(e) {
+    // JS should not catch in default mode
+    print("JS caught exception");
+}
+EOT;
+
+for($i = 0; $i < 5; $i ++) {
+    var_dump($i);
+    try {
+        $v8->executeString($JS);
+    } catch (Exception $e) {
+        var_dump($e->getMessage());
+    }
+}
+?>
+===EOF===
+--EXPECTF--
+int(0)
+string(14) "Test-Exception"
+int(1)
+string(14) "Test-Exception"
+int(2)
+string(14) "Test-Exception"
+int(3)
+string(14) "Test-Exception"
+int(4)
+string(14) "Test-Exception"
+===EOF===

--- a/tests/php_exceptions_002.phpt
+++ b/tests/php_exceptions_002.phpt
@@ -1,0 +1,67 @@
+--TEST--
+Test V8::executeString() : PHP Exception handling (multi-level)
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+--FILE--
+<?php
+
+class Foo {
+    function throwException() {
+	throw new \Exception("Test-Exception");
+    }
+
+    function recurse($i) {
+        echo "recurse[$i] ...\n";
+        global $work;
+        $work($i);
+    }
+}
+
+$v8 = new V8Js();
+$v8->foo = new \Foo();
+
+$work = $v8->executeString(<<<EOT
+var work = function(level) {
+  if(level--) {
+    PHP.foo.recurse(level);
+  }
+  else {
+    PHP.foo.throwException();
+  }
+};
+work;
+EOT
+);
+
+for($i = 0; $i < 5; $i ++) {
+    var_dump($i);
+    try {
+        $work($i);
+    } catch (Exception $e) {
+        var_dump($e->getMessage());
+    }
+}
+?>
+===EOF===
+--EXPECT--
+int(0)
+string(14) "Test-Exception"
+int(1)
+recurse[0] ...
+string(14) "Test-Exception"
+int(2)
+recurse[1] ...
+recurse[0] ...
+string(14) "Test-Exception"
+int(3)
+recurse[2] ...
+recurse[1] ...
+recurse[0] ...
+string(14) "Test-Exception"
+int(4)
+recurse[3] ...
+recurse[2] ...
+recurse[1] ...
+recurse[0] ...
+string(14) "Test-Exception"
+===EOF===

--- a/tests/php_exceptions_003.phpt
+++ b/tests/php_exceptions_003.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Test V8::executeString() : PHP Exception handling (basic JS propagation)
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+--FILE--
+<?php
+
+class Foo {
+    function throwException() {
+	throw new \Exception("Test-Exception");
+    }
+}
+
+$v8 = new V8Js();
+$v8->foo = new \Foo();
+
+$JS = <<< EOT
+try {
+    PHP.foo.throwException();
+    // the exception should abort further execution,
+    // hence the print must not pop up
+    print("after throwException\\n");
+} catch(e) {
+    print("JS caught exception!\\n");
+    var_dump(e.getMessage());
+}
+EOT;
+
+$v8->executeString($JS, 'php_exceptions_003', V8Js::FLAG_PROPAGATE_PHP_EXCEPTIONS);
+
+?>
+===EOF===
+--EXPECTF--
+JS caught exception!
+string(14) "Test-Exception"
+===EOF===

--- a/tests/php_exceptions_004.phpt
+++ b/tests/php_exceptions_004.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Test V8::executeString() : PHP Exception handling (PHP->JS->PHP back propagation)
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+--FILE--
+<?php
+
+class Foo {
+    function throwException() {
+	throw new \Exception("Test-Exception");
+    }
+}
+
+$v8 = new V8Js();
+$v8->foo = new \Foo();
+
+$JS = <<< EOT
+PHP.foo.throwException();
+// the exception should abort further execution,
+// hence the print must not pop up
+print("after throwException\\n");
+EOT;
+
+try {
+    $v8->executeString($JS, 'php_exceptions_004', V8Js::FLAG_PROPAGATE_PHP_EXCEPTIONS);
+}
+catch(V8JsScriptException $e) {
+    echo "Got V8JsScriptException\n";
+    var_dump($e->getPrevious()->getMessage());
+}
+?>
+===EOF===
+--EXPECTF--
+Got V8JsScriptException
+string(14) "Test-Exception"
+===EOF===

--- a/tests/php_exceptions_005.phpt
+++ b/tests/php_exceptions_005.phpt
@@ -34,7 +34,7 @@ catch(V8JsScriptException $e) {
 --EXPECTF--
 after getException
 Got V8JsScriptException
-string(329) "php_exceptions_005:3: exception 'Exception' with message 'Test-Exception' in %s
+string(%d) "php_exceptions_005:3: exception 'Exception' with message 'Test-Exception' in %s
 Stack trace:
 #0 [internal function]: Foo->getException()
 #1 %s: V8Js->executeString('var ex = PHP.fo...', 'php_exceptions_...')

--- a/tests/php_exceptions_005.phpt
+++ b/tests/php_exceptions_005.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Test V8::executeString() : PHP Exception handling (JS throw PHP-exception)
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+--FILE--
+<?php
+
+class Foo {
+    function getException() {
+        return new \Exception("Test-Exception");
+    }
+}
+
+$v8 = new V8Js();
+$v8->foo = new \Foo();
+
+$JS = <<< EOT
+var ex = PHP.foo.getException();
+print("after getException\\n");
+throw ex;
+print("after throw\\n");
+EOT;
+
+try {
+    $v8->executeString($JS, 'php_exceptions_005');
+}
+catch(V8JsScriptException $e) {
+    echo "Got V8JsScriptException\n";
+    var_dump($e->getMessage());
+    var_dump($e->getPrevious()->getMessage());
+}
+?>
+===EOF===
+--EXPECTF--
+after getException
+Got V8JsScriptException
+string(329) "php_exceptions_005:3: exception 'Exception' with message 'Test-Exception' in %s
+Stack trace:
+#0 [internal function]: Foo->getException()
+#1 %s: V8Js->executeString('var ex = PHP.fo...', 'php_exceptions_...')
+#2 {main}"
+string(14) "Test-Exception"
+===EOF===

--- a/tests/php_exceptions_006.phpt
+++ b/tests/php_exceptions_006.phpt
@@ -1,0 +1,40 @@
+--TEST--
+Test V8::executeString() : PHP Exception handling (JS throws normal PHP-object)
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+--FILE--
+<?php
+
+class Foo {
+    function getNonExceptionObject() {
+        return new \Foo();
+    }
+}
+
+$v8 = new V8Js();
+$v8->foo = new \Foo();
+
+$JS = <<< EOT
+var ex = PHP.foo.getNonExceptionObject();
+print("after getNonExceptionObject\\n");
+throw ex;
+print("after throw\\n");
+EOT;
+
+try {
+    $v8->executeString($JS, 'php_exceptions_006');
+}
+catch(V8JsScriptException $e) {
+    echo "Got V8JsScriptException\n";
+    var_dump($e->getMessage());
+    // previous exception should be NULL, as it is *not* a php exception
+    var_dump($e->getPrevious());
+}
+?>
+===EOF===
+--EXPECTF--
+after getNonExceptionObject
+Got V8JsScriptException
+string(34) "php_exceptions_006:3: [object Foo]"
+NULL
+===EOF===

--- a/tests/php_exceptions_basic.phpt
+++ b/tests/php_exceptions_basic.phpt
@@ -1,0 +1,42 @@
+--TEST--
+Test V8::executeString() : PHP Exception handling (basic)
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+--FILE--
+<?php
+
+class Foo {
+    function throwException() {
+	throw new \Exception("Test-Exception");
+    }
+}
+
+$v8 = new V8Js();
+$v8->foo = new \Foo();
+
+$JS = <<< EOT
+try {
+    PHP.foo.throwException();
+    // the exception should abort further execution,
+    // hence the print must not pop up
+    print("after throwException\\n");
+} catch(e) {
+    // JS should not catch in default mode
+    print("JS caught exception");
+}
+EOT;
+
+try {
+    $v8->executeString($JS);
+} catch (Exception $e) {
+    var_dump($e->getMessage());
+    var_dump($e->getFile());
+    var_dump($e->getLine());
+}
+?>
+===EOF===
+--EXPECTF--
+string(14) "Test-Exception"
+string(%d) "%sphp_exceptions_basic.php"
+int(5)
+===EOF===

--- a/v8js.cc
+++ b/v8js.cc
@@ -82,10 +82,28 @@ static ZEND_INI_MH(v8js_OnUpdateUseArrayAccess) /* {{{ */
 }
 /* }}} */
 
+static ZEND_INI_MH(v8js_OnUpdateCompatExceptions) /* {{{ */
+{
+	bool value;
+	if (new_value_length==2 && strcasecmp("on", new_value)==0) {
+		value = (bool) 1;
+    } else if (new_value_length==3 && strcasecmp("yes", new_value)==0) {
+		value = (bool) 1;
+	} else if (new_value_length==4 && strcasecmp("true", new_value)==0) {
+		value = (bool) 1;
+	} else {
+		value = (bool) atoi(new_value);
+	}
+	V8JSG(compat_php_exceptions) = value;
+	return SUCCESS;
+}
+/* }}} */
+
 ZEND_INI_BEGIN() /* {{{ */
 	ZEND_INI_ENTRY("v8js.flags", NULL, ZEND_INI_ALL, v8js_OnUpdateV8Flags)
 	ZEND_INI_ENTRY("v8js.use_date", "0", ZEND_INI_ALL, v8js_OnUpdateUseDate)
 	ZEND_INI_ENTRY("v8js.use_array_access", "0", ZEND_INI_ALL, v8js_OnUpdateUseArrayAccess)
+	ZEND_INI_ENTRY("v8js.compat_php_exceptions", "0", ZEND_INI_ALL, v8js_OnUpdateCompatExceptions)
 ZEND_INI_END()
 /* }}} */
 

--- a/v8js_class.cc
+++ b/v8js_class.cc
@@ -2,12 +2,13 @@
   +----------------------------------------------------------------------+
   | PHP Version 5                                                        |
   +----------------------------------------------------------------------+
-  | Copyright (c) 1997-2013 The PHP Group                                |
+  | Copyright (c) 1997-2015 The PHP Group                                |
   +----------------------------------------------------------------------+
   | http://www.opensource.org/licenses/mit-license.php  MIT License      |
   +----------------------------------------------------------------------+
   | Author: Jani Taskinen <jani.taskinen@iki.fi>                         |
   | Author: Patrick Reilly <preilly@php.net>                             |
+  | Author: Stefan Siegl <stesie@php.net>                                |
   +----------------------------------------------------------------------+
 */
 
@@ -498,7 +499,7 @@ static void v8js_compile_script(zval *this_ptr, const char *str, int str_len, co
 
 	/* Compile errors? */
 	if (script.IsEmpty()) {
-		v8js_throw_script_exception(&try_catch TSRMLS_CC);
+		v8js_throw_script_exception(c->isolate, &try_catch TSRMLS_CC);
 		return;
 	}
 	res = (v8js_script *)emalloc(sizeof(v8js_script));

--- a/v8js_class.cc
+++ b/v8js_class.cc
@@ -1078,6 +1078,7 @@ PHP_MINIT_FUNCTION(v8js_class) /* {{{ */
 
 	zend_declare_class_constant_long(php_ce_v8js, ZEND_STRL("FLAG_NONE"),			V8JS_FLAG_NONE			TSRMLS_CC);
 	zend_declare_class_constant_long(php_ce_v8js, ZEND_STRL("FLAG_FORCE_ARRAY"),	V8JS_FLAG_FORCE_ARRAY	TSRMLS_CC);
+	zend_declare_class_constant_long(php_ce_v8js, ZEND_STRL("FLAG_PROPAGATE_PHP_EXCEPTIONS"), V8JS_FLAG_PROPAGATE_PHP_EXCEPTIONS TSRMLS_CC);
 
 #ifdef ENABLE_DEBUGGER_SUPPORT
 	zend_declare_class_constant_long(php_ce_v8js, ZEND_STRL("DEBUG_AUTO_BREAK_NEVER"),	V8JS_DEBUG_AUTO_BREAK_NEVER			TSRMLS_CC);

--- a/v8js_class.h
+++ b/v8js_class.h
@@ -40,6 +40,8 @@ struct v8js_ctx {
   int in_execution;
   v8::Isolate *isolate;
 
+  long flags;
+
   long time_limit;
   bool time_limit_hit;
   long memory_limit;

--- a/v8js_exceptions.cc
+++ b/v8js_exceptions.cc
@@ -89,7 +89,11 @@ void v8js_create_script_exception(zval *return_value, v8::Isolate *isolate, v8::
 			if(!php_ref.IsEmpty()) {
 				assert(php_ref->IsExternal());
 				zval *php_exception = reinterpret_cast<zval *>(v8::External::Cast(*php_ref)->Value());
-				zend_exception_set_previous(return_value, php_exception TSRMLS_CC);
+
+				zend_class_entry *exception_ce = zend_exception_get_default(TSRMLS_C);
+				if (Z_TYPE_P(php_exception) == IS_OBJECT && instanceof_function(Z_OBJCE_P(php_exception), exception_ce TSRMLS_CC)) {
+					zend_exception_set_previous(return_value, php_exception TSRMLS_CC);
+				}
 			}
 		}
 

--- a/v8js_exceptions.h
+++ b/v8js_exceptions.h
@@ -2,12 +2,13 @@
   +----------------------------------------------------------------------+
   | PHP Version 5                                                        |
   +----------------------------------------------------------------------+
-  | Copyright (c) 1997-2013 The PHP Group                                |
+  | Copyright (c) 1997-2015 The PHP Group                                |
   +----------------------------------------------------------------------+
   | http://www.opensource.org/licenses/mit-license.php  MIT License      |
   +----------------------------------------------------------------------+
   | Author: Jani Taskinen <jani.taskinen@iki.fi>                         |
   | Author: Patrick Reilly <preilly@php.net>                             |
+  | Author: Stefan Siegl <stesie@php.net>                                |
   +----------------------------------------------------------------------+
 */
 
@@ -19,8 +20,8 @@ extern zend_class_entry *php_ce_v8js_script_exception;
 extern zend_class_entry *php_ce_v8js_time_limit_exception;
 extern zend_class_entry *php_ce_v8js_memory_limit_exception;
 
-void v8js_create_script_exception(zval *return_value, v8::TryCatch *try_catch TSRMLS_DC);
-void v8js_throw_script_exception(v8::TryCatch *try_catch TSRMLS_DC);
+void v8js_create_script_exception(zval *return_value, v8::Isolate *isolate, v8::TryCatch *try_catch TSRMLS_DC);
+void v8js_throw_script_exception(v8::Isolate *isolate, v8::TryCatch *try_catch TSRMLS_DC);
 
 PHP_MINIT_FUNCTION(v8js_exceptions);
 

--- a/v8js_methods.cc
+++ b/v8js_methods.cc
@@ -26,20 +26,7 @@ extern "C" {
 V8JS_METHOD(exit) /* {{{ */
 {
 	v8::Isolate *isolate = info.GetIsolate();
-
-	/* Unfortunately just calling TerminateExecution on the isolate is not
-	 * enough, since v8 just marks the thread as "to be aborted" and doesn't
-	 * immediately do so.  Hence we enter an endless loop after signalling
-	 * termination, so we definitely don't execute JS code after the exit()
-	 * statement. */
-	v8::Locker locker(isolate);
-	v8::Isolate::Scope isolate_scope(isolate);
-	v8::HandleScope handle_scope(isolate);
-
-	v8::Local<v8::String> source = V8JS_STR("for(;;);");
-	v8::Local<v8::Script> script = v8::Script::Compile(source);
-	v8::V8::TerminateExecution(isolate);
-	script->Run();
+	v8js_terminate_execution(isolate);
 }
 /* }}} */
 

--- a/v8js_object_export.cc
+++ b/v8js_object_export.cc
@@ -149,7 +149,7 @@ failure:
 		efree(fci.params);
 	}
 
-	if(EG(exception)) {
+	if(EG(exception) && !V8JSG(compat_php_exceptions)) {
 		if(ctx->flags & V8JS_FLAG_PROPAGATE_PHP_EXCEPTIONS) {
 			return_value = isolate->ThrowException(zval_to_v8js(EG(exception), isolate TSRMLS_CC));
 			zend_clear_exception(TSRMLS_C);

--- a/v8js_object_export.cc
+++ b/v8js_object_export.cc
@@ -134,10 +134,14 @@ static void v8js_call_php_func(zval *value, zend_class_entry *ce, zend_function 
 		isolate->Enter();
 	}
 	zend_catch {
-		v8::V8::TerminateExecution(isolate);
+		v8js_terminate_execution(isolate);
 		V8JSG(fatal_error_abort) = 1;
 	}
 	zend_end_try();
+
+	if(EG(exception)) {
+		v8js_terminate_execution(isolate);
+	}
 
 failure:
 	/* Cleanup */

--- a/v8js_timer.cc
+++ b/v8js_timer.cc
@@ -55,7 +55,7 @@ static void v8js_timer_interrupt_handler(v8::Isolate *isolate, void *data) { /* 
 
 		if (timer_ctx->memory_limit > 0 && hs.used_heap_size() > timer_ctx->memory_limit) {
 			timer_ctx->killed = true;
-			v8js_terminate_execution(c TSRMLS_CC);
+			v8::V8::TerminateExecution(c->isolate);
 			c->memory_limit_hit = true;
 		}
 	}
@@ -80,7 +80,7 @@ void v8js_timer_thread(TSRMLS_D) /* {{{ */
 			}
 			else if(timer_ctx->time_limit > 0 && now > timer_ctx->time_point) {
 				timer_ctx->killed = true;
-				v8js_terminate_execution(c TSRMLS_CC);
+				v8::V8::TerminateExecution(c->isolate);
 				c->time_limit_hit = true;
 			}
 			else if (timer_ctx->memory_limit > 0) {

--- a/v8js_v8.cc
+++ b/v8js_v8.cc
@@ -2,12 +2,13 @@
   +----------------------------------------------------------------------+
   | PHP Version 5                                                        |
   +----------------------------------------------------------------------+
-  | Copyright (c) 1997-2013 The PHP Group                                |
+  | Copyright (c) 1997-2015 The PHP Group                                |
   +----------------------------------------------------------------------+
   | http://www.opensource.org/licenses/mit-license.php  MIT License      |
   +----------------------------------------------------------------------+
   | Author: Jani Taskinen <jani.taskinen@iki.fi>                         |
   | Author: Patrick Reilly <preilly@php.net>                             |
+  | Author: Stefan Siegl <stesie@php.net>                                |
   +----------------------------------------------------------------------+
 */
 
@@ -175,14 +176,14 @@ void v8js_v8_call(v8js_ctx *c, zval **return_value,
 
 			/* Report immediately if report_uncaught is true */
 			if (c->report_uncaught) {
-				v8js_throw_script_exception(&try_catch TSRMLS_CC);
+				v8js_throw_script_exception(c->isolate, &try_catch TSRMLS_CC);
 				return;
 			}
 
 			/* Exception thrown from JS, preserve it for future execution */
 			if (result.IsEmpty()) {
 				MAKE_STD_ZVAL(c->pending_exception);
-				v8js_create_script_exception(c->pending_exception, &try_catch TSRMLS_CC);
+				v8js_create_script_exception(c->pending_exception, c->isolate, &try_catch TSRMLS_CC);
 				return;
 			}
 		}

--- a/v8js_v8.cc
+++ b/v8js_v8.cc
@@ -202,6 +202,13 @@ void v8js_v8_call(v8js_ctx *c, zval **return_value,
 
 void v8js_terminate_execution(v8::Isolate *isolate) /* {{{ */
 {
+	if(v8::V8::IsExecutionTerminating(isolate)) {
+		/* Execution already terminating, needn't trigger it again and
+		 * especially must not execute the spinning loop (which would cause
+		 * crashes in V8 itself, at least with 4.2 and 4.3 version lines). */
+		return;
+	}
+
 	/* Unfortunately just calling TerminateExecution on the isolate is not
 	 * enough, since v8 just marks the thread as "to be aborted" and doesn't
 	 * immediately do so.  Hence we enter an endless loop after signalling

--- a/v8js_v8.cc
+++ b/v8js_v8.cc
@@ -77,7 +77,7 @@ void v8js_v8_call(v8js_ctx *c, zval **return_value,
 	v8::TryCatch try_catch;
 
 	/* Set flags for runtime use */
-	V8JS_GLOBAL_SET_FLAGS(isolate, flags);
+	c->flags = flags;
 
 	/* Check if timezone has been changed and notify V8 */
 	tz = getenv("TZ");

--- a/v8js_v8.h
+++ b/v8js_v8.h
@@ -45,7 +45,7 @@ void v8js_v8_init(TSRMLS_D);
 void v8js_v8_call(v8js_ctx *c, zval **return_value,
 				  long flags, long time_limit, long memory_limit,
 				  std::function< v8::Local<v8::Value>(v8::Isolate *) >& v8_call TSRMLS_DC);
-void v8js_terminate_execution(v8js_ctx *c TSRMLS_DC);
+void v8js_terminate_execution(v8::Isolate *isolate);
 
 /* Fetch V8 object properties */
 int v8js_get_properties_hash(v8::Handle<v8::Value> jsValue, HashTable *retval, int flags, v8::Isolate *isolate TSRMLS_DC);


### PR DESCRIPTION
This pull requests adds (optional) support to propagate PHP exceptions to JavaScript.  This can be enabled by passing the `FLAG_PROPAGATE_PHP_EXCEPTIONS` flag to `executeString` method.

If set, thrown PHP exception objects are converted to JavaScript objects obeying normal conversion behaviour and thrown in JavaScript.  This is all public method (and properties) can be used on the caught exception object from JavaScript side.

If JS doesn't catch the exception a V8JsException is thrown that points to the original PHP exception via (private) previous property, that can be got with `getPrevious()` method.

@tahpot, @rosmo looking forward to your review

this pull request fixes #144 