### PR TITLE
Cache pseudo-Array FunctionTemplate as well

### DIFF
--- a/v8js_class.cc
+++ b/v8js_class.cc
@@ -108,6 +108,8 @@ static void v8js_free_storage(void *object TSRMLS_DC) /* {{{ */
 	c->object_name.~Persistent();
 	c->global_template.Reset();
 	c->global_template.~Persistent();
+	c->array_tmpl.Reset();
+	c->array_tmpl.~Persistent();
 
 	/* Clear persistent call_impl & method_tmpls templates */
 	for (std::map<v8js_tmpl_t *, v8js_tmpl_t>::iterator it = c->call_impls.begin();
@@ -221,6 +223,7 @@ static zend_object_value v8js_new(zend_class_entry *ce TSRMLS_DC) /* {{{ */
 	new(&c->object_name) v8::Persistent<v8::String>();
 	new(&c->context) v8::Persistent<v8::Context>();
 	new(&c->global_template) v8::Persistent<v8::FunctionTemplate>();
+	new(&c->array_tmpl) v8::Persistent<v8::FunctionTemplate>();
 
 	new(&c->modules_stack) std::vector<char*>();
 	new(&c->modules_base) std::vector<char*>();

--- a/v8js_class.h
+++ b/v8js_class.h
@@ -45,7 +45,8 @@ struct v8js_ctx {
   long memory_limit;
   bool memory_limit_hit;
 
-  v8::Persistent<v8::FunctionTemplate> global_template;
+  v8js_tmpl_t global_template;
+  v8js_tmpl_t array_tmpl;
 
   zval *module_loader;
   std::vector<char *> modules_stack;

--- a/v8js_object_export.cc
+++ b/v8js_object_export.cc
@@ -901,12 +901,22 @@ static v8::Handle<v8::Object> v8js_wrap_array_to_object(v8::Isolate *isolate, zv
 	uint key_len;
 	ulong index;
 
-	// @todo re-use template likewise
-	v8::Local<v8::FunctionTemplate> new_tpl = v8::FunctionTemplate::New(isolate, 0);
+	v8js_ctx *ctx = (v8js_ctx *) isolate->GetData(0);
+	v8::Local<v8::FunctionTemplate> new_tpl;
 
-	/* Call it Array, but it is not a native array, especially it doesn't have
-	 * have the typical Array.prototype functions. */
-	new_tpl->SetClassName(V8JS_SYM("Array"));
+	if(ctx->array_tmpl.IsEmpty()) {
+		new_tpl = v8::FunctionTemplate::New(isolate, 0);
+
+		/* Call it Array, but it is not a native array, especially it doesn't have
+		 * have the typical Array.prototype functions. */
+		new_tpl->SetClassName(V8JS_SYM("Array"));
+
+		/* Store for later re-use */
+		ctx->array_tmpl.Reset(isolate, new_tpl);
+	}
+	else {
+		new_tpl = v8::Local<v8::FunctionTemplate>::New(isolate, ctx->array_tmpl);
+	}
 
 	v8::Handle<v8::Object> newobj = new_tpl->InstanceTemplate()->NewInstance();
 


### PR DESCRIPTION
It was already noted `@todo` in the code, but never implemented.

Currently we create a new `v8::FunctionTemplate` on every export of a PHP array to V8. Unfortunately those are *not* object to garbage collection, hence it is a particular bad to repeatedly create those templates, if the PHP code exports millions of arrays to V8 :-)

Now the global `v8js_ctx` has a persistent refernce to the `FunctionTemplate`, which now is initialized on first Array-export to V8. Succeeding exports re-use the template; and finally the reference is cleared on isolate deconstruction.